### PR TITLE
Unique validation functions for contract and receive names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -148,6 +150,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -174,6 +178,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -225,6 +231,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "concordium-contracts-common"]
+	path = concordium-contracts-common
+	url = git@github.com:Concordium/concordium-contracts-common.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "concordium-contracts-common"]
 	path = concordium-contracts-common
-	url = git@github.com:Concordium/concordium-contracts-common.git
+	url = ../concordium-contracts-common.git

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "concordium-contracts-common"
 version = "0.4.0"
-source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=main#81e8be24984b7c6f1753c2e1a732a6eaf2fa604b"
+source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d1476d46ac3ce5fd01f61073af1f7cb77a3964b3"
 dependencies = [
  "base58check",
  "chrono",
@@ -937,6 +937,7 @@ name = "wasm-transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "concordium-contracts-common",
  "leb128",
  "num_enum",
 ]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -187,8 +187,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "0.4.0"
-source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d1476d46ac3ce5fd01f61073af1f7cb77a3964b3"
+version = "0.4.1"
 dependencies = [
  "base58check",
  "chrono",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -30,7 +30,6 @@ path = "../wasm-chain-integration/"
 criterion = "0.3"
 
 [dependencies.concordium-contracts-common]
-version = "0.4"
-git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "validate-contract-and-receive-names"
+version = "0.4.1"
+path = "../concordium-contracts-common"
 features = ["derive-serde", "std"]

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -32,5 +32,5 @@ criterion = "0.3"
 [dependencies.concordium-contracts-common]
 version = "0.4"
 git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "main"
+branch = "validate-contract-and-receive-names"
 features = ["derive-serde", "std"]

--- a/wasm-chain-integration/Cargo.lock
+++ b/wasm-chain-integration/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 name = "concordium-contracts-common"
 version = "0.4.0"
-source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=main#81e8be24984b7c6f1753c2e1a732a6eaf2fa604b"
+source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d11f71ef1e5c206503d4c65ee81425bb31cdb45b"
 dependencies = [
  "base58check",
  "chrono",
@@ -859,6 +859,7 @@ name = "wasm-transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "concordium-contracts-common",
  "leb128",
  "num_enum",
 ]

--- a/wasm-chain-integration/Cargo.lock
+++ b/wasm-chain-integration/Cargo.lock
@@ -146,8 +146,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "0.4.0"
-source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d11f71ef1e5c206503d4c65ee81425bb31cdb45b"
+version = "0.4.1"
 dependencies = [
  "base58check",
  "chrono",

--- a/wasm-chain-integration/Cargo.toml
+++ b/wasm-chain-integration/Cargo.toml
@@ -27,10 +27,8 @@ path = "../wasm-transform"
 version = "0"
 
 [dependencies.concordium-contracts-common]
-# version = "0.4"
-git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "validate-contract-and-receive-names"
-# path = "../../concordium-rust-smart-contracts/concordium-contracts-common"
+version = "0.4.1"
+path = "../concordium-contracts-common"
 features = ["derive-serde"]
 
 [lib]

--- a/wasm-chain-integration/Cargo.toml
+++ b/wasm-chain-integration/Cargo.toml
@@ -27,9 +27,10 @@ path = "../wasm-transform"
 version = "0"
 
 [dependencies.concordium-contracts-common]
-version = "0.4"
+# version = "0.4"
 git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "main"
+branch = "validate-contract-and-receive-names"
+# path = "../../concordium-rust-smart-contracts/concordium-contracts-common"
 features = ["derive-serde"]
 
 [lib]

--- a/wasm-chain-integration/src/lib.rs
+++ b/wasm-chain-integration/src/lib.rs
@@ -168,7 +168,7 @@ impl Outcome {
         let response = self.cur_state.len();
 
         let name_str = std::str::from_utf8(receive_name_bytes)?;
-        ensure!(validate::is_valid_receive_name(name_str), "Not a valid receive name.");
+        ensure!(ReceiveName::is_valid_receive_name(name_str).is_ok(), "Not a valid receive name.");
         let name = receive_name_bytes.to_vec();
 
         ensure!(parameter_bytes.len() <= MAX_PARAMETER_SIZE, "Parameter exceeds max size.");

--- a/wasm-test/Cargo.lock
+++ b/wasm-test/Cargo.lock
@@ -36,10 +36,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base58"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+
+[[package]]
+name = "base58check"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee2fe4c9a0c84515f136aaae2466744a721af6d63339c18689d9e995d74d99b"
+dependencies = [
+ "base58",
+ "sha2",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -57,6 +125,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "concordium-contracts-common"
+version = "0.4.0"
+source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d1476d46ac3ce5fd01f61073af1f7cb77a3964b3"
+dependencies = [
+ "base58check",
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +144,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -86,6 +189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +211,25 @@ name = "libc"
 version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_enum"
@@ -124,6 +252,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -177,10 +311,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "serde"
 version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
 
 [[package]]
 name = "strsim"
@@ -233,6 +410,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +428,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-segmentation"
@@ -272,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
 name = "wasm-test"
 version = "0.1.0"
 dependencies = [
@@ -288,6 +488,7 @@ name = "wasm-transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "concordium-contracts-common",
  "leb128",
  "num_enum",
 ]

--- a/wasm-test/Cargo.lock
+++ b/wasm-test/Cargo.lock
@@ -126,8 +126,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "0.4.0"
-source = "git+https://github.com/Concordium/concordium-contracts-common.git?branch=validate-contract-and-receive-names#d1476d46ac3ce5fd01f61073af1f7cb77a3964b3"
+version = "0.4.1"
 dependencies = [
  "base58check",
  "chrono",

--- a/wasm-transform/Cargo.toml
+++ b/wasm-transform/Cargo.toml
@@ -14,5 +14,13 @@ leb128 = "0.2.4"
 anyhow = "1.0.33"
 num_enum = "0.5"
 
+
+[dependencies.concordium-contracts-common]
+# version = "0.4"
+git = "https://github.com/Concordium/concordium-contracts-common.git"
+branch = "validate-contract-and-receive-names"
+# path = "../../concordium-rust-smart-contracts/concordium-contracts-common"
+features = ["derive-serde"]
+
 [lib]
 crate-type = ["rlib"]

--- a/wasm-transform/Cargo.toml
+++ b/wasm-transform/Cargo.toml
@@ -16,10 +16,8 @@ num_enum = "0.5"
 
 
 [dependencies.concordium-contracts-common]
-# version = "0.4"
-git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "validate-contract-and-receive-names"
-# path = "../../concordium-rust-smart-contracts/concordium-contracts-common"
+version = "0.4.1"
+path = "../concordium-contracts-common"
 features = ["derive-serde"]
 
 [lib]

--- a/wasm-transform/Changelog.md
+++ b/wasm-transform/Changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased changes
+- Move contract and receive-name validation functions to concordium-contracts-common
+- Move `MAX_FUNC_NAME_SIZE` to concordium-contracts-common
+

--- a/wasm-transform/src/constants.rs
+++ b/wasm-transform/src/constants.rs
@@ -49,13 +49,10 @@ pub const MAX_NUM_EXPORTS: usize = 100;
 
 /// Maximum size of names.
 /// NB: Function names are restricted further. See
-/// [MAX_FUNC_NAME_SIZE](./constant.MAX_FUNC_NAME_SIZE.html).
+/// [concordium-contracts-common::constants::MAX_FUNC_NAME_SIZE][m]
+///
+/// [m]: https://docs.rs/concordium-contracts-common/*/concordium_contracts_common/constant.MAX_FUNC_NAME_SIZE.html
 pub const MAX_NAME_SIZE: usize = 512;
-
-/// Maximum size of function names.
-/// A contract name is defined by its init name, so this also limits the size
-/// of contract names.
-pub const MAX_FUNC_NAME_SIZE: usize = 100;
 
 /// The Wasm binary format magic hash.
 pub const MAGIC_HASH: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];

--- a/wasm-transform/src/machine.rs
+++ b/wasm-transform/src/machine.rs
@@ -329,7 +329,7 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
         // for now.
         ensure!(start as usize >= self.imports.len(), RuntimeError::DirectlyCallImport);
         let outer_function = &self.code[start as usize - self.imports.len()]; // safe because the artifact should be well-formed.
-        let num_args = args.len().try_into()?;
+        let num_args: u32 = args.len().try_into()?;
         ensure!(
             outer_function.num_params() == num_args,
             "The number of arguments does not match the number of parameters {} != {}.",

--- a/wasm-transform/src/parse.rs
+++ b/wasm-transform/src/parse.rs
@@ -670,7 +670,10 @@ impl<'a, Ctx: Copy> Parseable<'a, Ctx> for Export {
             ..
         } = description
         {
-            ensure!(name.name.len() <= MAX_FUNC_NAME_SIZE, ParseError::FuncNameTooLong);
+            ensure!(
+                name.name.len() <= concordium_contracts_common::constants::MAX_FUNC_NAME_SIZE,
+                ParseError::FuncNameTooLong
+            );
         }
 
         Ok(Export {
@@ -857,9 +860,11 @@ impl std::fmt::Display for ParseError {
             ParseError::OnlySingleReturn => write!(f, "Only single return value is supported."),
             ParseError::OnlyASCIINames => write!(f, "Only ASCII names are allowed."),
             ParseError::NameTooLong => write!(f, "Names are limited to {} bytes.", MAX_NAME_SIZE),
-            ParseError::FuncNameTooLong => {
-                write!(f, "Names of functions are limited to {} bytes.", MAX_FUNC_NAME_SIZE)
-            }
+            ParseError::FuncNameTooLong => write!(
+                f,
+                "Names of functions are limited to {} bytes.",
+                concordium_contracts_common::constants::MAX_FUNC_NAME_SIZE
+            ),
             ParseError::StartFunctionsNotSupported => {
                 write!(f, "Start functions are not supported.")
             }

--- a/wasm-transform/src/validate.rs
+++ b/wasm-transform/src/validate.rs
@@ -39,41 +39,6 @@ impl std::fmt::Display for ValidationError {
     }
 }
 
-/// Check whether the given string is a valid contract initialization function
-/// name. This is the case if and only if
-/// - the string is no more than
-///   [constants::MAX_FUNC_NAME_SIZE](../constants/constant.MAX_FUNC_NAME_SIZE.
-///   html) bytes
-/// - the string starts with `init_`
-/// - the string __does not__ contain a `.`
-/// - all characters are ascii alphanumeric or punctuation characters.
-pub fn is_valid_init_name(bs: &str) -> bool {
-    if bs.as_bytes().len() > MAX_FUNC_NAME_SIZE {
-        return false;
-    }
-    let valid_characters =
-        bs.chars().all(|c| c.is_ascii_alphanumeric() || c.is_ascii_punctuation());
-    let starts_with = bs.starts_with("init_");
-    let has_dot = bs.contains('.');
-    valid_characters && starts_with && !has_dot
-}
-
-/// Check whether the given string is a valid contract receive function name.
-/// This is the case if and only if
-/// - the string is no more than
-///   [constants::MAX_FUNC_NAME_SIZE](../constants/constant.MAX_FUNC_NAME_SIZE.
-///   html) bytes
-/// - the string __contains__ a `.`
-/// - all characters are ascii alphanumeric or punctuation characters.
-pub fn is_valid_receive_name(bs: &str) -> bool {
-    if bs.as_bytes().len() > MAX_FUNC_NAME_SIZE {
-        return false;
-    }
-    let valid_characters =
-        bs.chars().all(|c| c.is_ascii_alphanumeric() || c.is_ascii_punctuation());
-    valid_characters && bs.contains('.')
-}
-
 /// Result type of validation.
 pub type ValidateResult<A> = anyhow::Result<A>;
 


### PR DESCRIPTION
## Purpose

Contract and receive names were being validated with different functions. Now, I've combined them into one (in contracts-common).

## Changes

- Remove validation functions and rely on the ones from concordium-contracts-common (https://github.com/Concordium/concordium-contracts-common/pull/19)
- Use `MAX_FUNC_NAME_SIZE` from concordium-contracts-common to avoid having the constant in both repositories.
- Added `concordium-contracts-common` as a submodule so that the CI can succeed without changing `Cargo.toml`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.