### PR TITLE
Use `size_length` instead of the removed `map_size_length`

### DIFF
--- a/rust-contracts/example-contracts/simple-game/Cargo.lock
+++ b/rust-contracts/example-contracts/simple-game/Cargo.lock
@@ -29,7 +29,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "concordium-std"
@@ -44,6 +44,7 @@ dependencies = [
 name = "concordium-std-derive"
 version = "0.5.0"
 dependencies = [
+ "concordium-contracts-common",
  "proc-macro2",
  "quote",
  "syn",

--- a/rust-contracts/example-contracts/simple-game/src/lib.rs
+++ b/rust-contracts/example-contracts/simple-game/src/lib.rs
@@ -59,7 +59,7 @@ struct State {
     prefix:            Prefix,
     /// Stored contributions. The Hash is the lowest per account, and the amount
     /// is the total amount contributed by this account.
-    #[concordium(map_size_length = 4)]
+    #[concordium(size_length = 4)]
     contributions:     collections::BTreeMap<AccountAddress, (Amount, Hash)>,
 }
 


### PR DESCRIPTION
## Purpose

Update to contract to work with https://github.com/Concordium/concordium-rust-smart-contracts/pull/39

## Changes

Change `map_size_length` to `size_length`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.