### PR TITLE
concordium/base image was moved to dockerhub

### DIFF
--- a/cargo-concordium/linux-cargo-concordium.Jenkinsfile
+++ b/cargo-concordium/linux-cargo-concordium.Jenkinsfile
@@ -12,15 +12,6 @@ pipeline {
         OUTFILE = "s3://distribution.concordium.software/tools/linux/cargo-concordium_${VERSION}"
     }
     stages {
-        stage('ecr-login') {
-            steps {
-                sh 'aws ecr get-login-password \
-                        --region eu-west-1 \
-                    | docker login \
-                        --username AWS \
-                        --password-stdin 192549843005.dkr.ecr.eu-west-1.amazonaws.com'
-            }
-        }
         stage('precheck') {
             steps {
                 sh '''\
@@ -37,8 +28,7 @@ pipeline {
             agent { 
                 docker {
                     reuseNode true
-                    image 'concordium/base:latest' 
-                    registryUrl 'https://192549843005.dkr.ecr.eu-west-1.amazonaws.com/'
+                    image 'concordium/base:latest'
                     args '-u root'
                 } 
             }


### PR DESCRIPTION
## Purpose

The concordium/base image was moved to dockerhub, so the Linux build no longer has any need to log into ECR or specify registry.

## Changes

ECR login and registry specification was removed from Linux build

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
