### PR TITLE
Support interruptable and resumable execution.

### DIFF
--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -201,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,19 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -953,6 +972,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
+ "derive_more",
  "leb128",
  "num_enum",
 ]

--- a/wasm-chain-integration/Cargo.lock
+++ b/wasm-chain-integration/Cargo.lock
@@ -113,7 +113,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -157,6 +157,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "criterion"
@@ -279,6 +285,19 @@ checksum = "b1a012b5e473dc912f0db0546a1c9c6a194ce8494feb66fa0237160926f9e0e6"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -479,6 +498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,11 +610,20 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -612,9 +649,27 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -746,6 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +929,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
+ "derive_more",
  "leb128",
  "num_enum",
 ]

--- a/wasm-chain-integration/src/lib.rs
+++ b/wasm-chain-integration/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod constants;
 #[cfg(feature = "enable-ffi")]
 mod ffi;
+#[cfg(feature = "fuzz")]
+pub mod fuzz;
+pub mod resumption;
+mod types;
 
 #[cfg(test)]
 mod validation_tests;
@@ -22,9 +26,6 @@ use wasm_transform::{
     types::{ExportDescription, Module, Name},
     utils, validate,
 };
-#[cfg(feature = "fuzz")]
-pub mod fuzz;
-mod types;
 
 pub type ExecResult<A> = anyhow::Result<A>;
 
@@ -131,7 +132,7 @@ impl InterpreterEnergy {
 }
 
 #[derive(Clone, Default)]
-/// The Default instance of this type constructs and empty list of outcomes.
+/// The Default instance of this type constructs an empty list of outcomes.
 pub struct Outcome {
     pub cur_state: Vec<Action>,
 }
@@ -273,7 +274,7 @@ impl State {
     }
 }
 
-pub struct InitHost<'a, Ctx> {
+pub struct InitHost<ParamType, Ctx> {
     /// Remaining energy for execution.
     pub energy:            InterpreterEnergy,
     /// Remaining amount of activation frames.
@@ -284,12 +285,12 @@ pub struct InitHost<'a, Ctx> {
     /// The contract's state.
     pub state:             State,
     /// The parameter to the init method.
-    pub param:             &'a [u8],
+    pub param:             ParamType,
     /// The init context for this invocation.
-    pub init_ctx:          &'a Ctx,
+    pub init_ctx:          Ctx,
 }
 
-pub struct ReceiveHost<'a, Ctx> {
+pub struct ReceiveHost<ParamType, Ctx> {
     /// Remaining energy for execution.
     pub energy:            InterpreterEnergy,
     /// Remaining amount of activation frames.
@@ -299,12 +300,12 @@ pub struct ReceiveHost<'a, Ctx> {
     pub logs:              Logs,
     /// The contract's state.
     pub state:             State,
-    /// The parameter to the init method.
-    pub param:             &'a [u8],
+    /// The parameter to the receive method.
+    pub param:             ParamType,
     /// Outcomes of the execution, i.e., the actions tree.
     pub outcomes:          Outcome,
     /// The receive context for this call.
-    pub receive_ctx:       &'a Ctx,
+    pub receive_ctx:       Ctx,
 }
 
 pub trait HasCommon {
@@ -320,7 +321,7 @@ pub trait HasCommon {
     fn metadata(&self) -> &Self::MetadataType;
 }
 
-impl<'a, Ctx: HasInitContext> HasCommon for InitHost<'a, Ctx> {
+impl<ParamType: AsRef<[u8]>, Ctx: HasInitContext> HasCommon for InitHost<ParamType, Ctx> {
     type MetadataType = Ctx::MetadataType;
     type PolicyBytesType = Ctx::PolicyBytesType;
     type PolicyType = Ctx::PolicyType;
@@ -331,14 +332,14 @@ impl<'a, Ctx: HasInitContext> HasCommon for InitHost<'a, Ctx> {
 
     fn state(&mut self) -> &mut State { &mut self.state }
 
-    fn param(&self) -> &[u8] { &self.param }
+    fn param(&self) -> &[u8] { self.param.as_ref() }
 
     fn metadata(&self) -> &Self::MetadataType { self.init_ctx.metadata() }
 
     fn policies(&self) -> ExecResult<&Self::PolicyType> { self.init_ctx.sender_policies() }
 }
 
-impl<'a, Ctx: HasReceiveContext> HasCommon for ReceiveHost<'a, Ctx> {
+impl<ParamType: AsRef<[u8]>, Ctx: HasReceiveContext> HasCommon for ReceiveHost<ParamType, Ctx> {
     type MetadataType = Ctx::MetadataType;
     type PolicyBytesType = Ctx::PolicyBytesType;
     type PolicyType = Ctx::PolicyType;
@@ -349,7 +350,7 @@ impl<'a, Ctx: HasReceiveContext> HasCommon for ReceiveHost<'a, Ctx> {
 
     fn state(&mut self) -> &mut State { &mut self.state }
 
-    fn param(&self) -> &[u8] { &self.param }
+    fn param(&self) -> &[u8] { self.param.as_ref() }
 
     fn metadata(&self) -> &Self::MetadataType { self.receive_ctx.metadata() }
 
@@ -374,6 +375,22 @@ pub trait HasInitContext {
     fn metadata(&self) -> &Self::MetadataType;
     fn init_origin(&self) -> ExecResult<&AccountAddress>;
     fn sender_policies(&self) -> ExecResult<&Self::PolicyType>;
+}
+
+/// Generic implementation for all references to types that already implement
+/// HasInitContext. This allows using InitContext as well as &InitContext in the
+/// init host, depending on whether we want to transfer ownership of the context
+/// or not.
+impl<'a, X: HasInitContext> HasInitContext for &'a X {
+    type MetadataType = X::MetadataType;
+    type PolicyBytesType = X::PolicyBytesType;
+    type PolicyType = X::PolicyType;
+
+    fn metadata(&self) -> &Self::MetadataType { (*self).metadata() }
+
+    fn init_origin(&self) -> ExecResult<&AccountAddress> { (*self).init_origin() }
+
+    fn sender_policies(&self) -> ExecResult<&Self::PolicyType> { (*self).sender_policies() }
 }
 
 impl HasInitContext for InitContext<Vec<OwnedPolicy>> {
@@ -422,6 +439,30 @@ pub trait HasReceiveContext {
     fn sender(&self) -> ExecResult<&Address>;
     fn owner(&self) -> ExecResult<&AccountAddress>;
     fn sender_policies(&self) -> ExecResult<&Self::PolicyType>;
+}
+
+/// Generic implementation for all references to types that already implement
+/// HasReceiveContext. This allows using ReceiveContext as well as
+/// &ReceiveContext in the receive host, depending on whether we want to
+/// transfer ownership of the context or not.
+impl<'a, X: HasReceiveContext> HasReceiveContext for &'a X {
+    type MetadataType = X::MetadataType;
+    type PolicyBytesType = X::PolicyBytesType;
+    type PolicyType = X::PolicyType;
+
+    fn metadata(&self) -> &Self::MetadataType { (*self).metadata() }
+
+    fn invoker(&self) -> ExecResult<&AccountAddress> { (*self).invoker() }
+
+    fn self_address(&self) -> ExecResult<&ContractAddress> { (*self).self_address() }
+
+    fn self_balance(&self) -> ExecResult<Amount> { (*self).self_balance() }
+
+    fn sender(&self) -> ExecResult<&Address> { (*self).sender() }
+
+    fn owner(&self) -> ExecResult<&AccountAddress> { (*self).owner() }
+
+    fn sender_policies(&self) -> ExecResult<&Self::PolicyType> { (*self).sender_policies() }
 }
 
 impl HasReceiveContext for ReceiveContext<Vec<OwnedPolicy>> {
@@ -574,7 +615,11 @@ fn call_common<C: HasCommon>(
     Ok(())
 }
 
-impl<'a, Ctx: HasInitContext> machine::Host<ProcessedImports> for InitHost<'a, Ctx> {
+impl<ParamType: AsRef<[u8]>, Ctx: HasInitContext> machine::Host<ProcessedImports>
+    for InitHost<ParamType, Ctx>
+{
+    type Interrupt = NoInterrupt;
+
     #[cfg_attr(not(feature = "fuzz-coverage"), inline(always))]
     fn tick_initial_memory(&mut self, num_pages: u32) -> machine::RunResult<()> {
         self.energy.charge_memory_alloc(num_pages)
@@ -617,8 +662,9 @@ impl<'a, Ctx: HasInitContext> machine::Host<ProcessedImports> for InitHost<'a, C
     }
 }
 
-impl<'a, Ctx> ReceiveHost<'a, Ctx>
+impl<ParamType, Ctx> ReceiveHost<ParamType, Ctx>
 where
+    ParamType: AsRef<[u8]>,
     Ctx: HasReceiveContext,
 {
     pub fn call_receive_only(
@@ -715,7 +761,11 @@ where
     }
 }
 
-impl<'a, Ctx: HasReceiveContext> machine::Host<ProcessedImports> for ReceiveHost<'a, Ctx> {
+impl<ParamType: AsRef<[u8]>, Ctx: HasReceiveContext> machine::Host<ProcessedImports>
+    for ReceiveHost<ParamType, Ctx>
+{
+    type Interrupt = NoInterrupt;
+
     #[cfg_attr(not(feature = "fuzz-coverage"), inline(always))]
     fn tick_initial_memory(&mut self, num_pages: u32) -> machine::RunResult<()> {
         self.energy.charge_memory_alloc(num_pages)
@@ -775,7 +825,7 @@ pub fn invoke_init<C: RunnableCode, Ctx: HasInitContext>(
         logs: Logs::new(),
         state: State::new(None),
         param,
-        init_ctx: &init_ctx,
+        init_ctx,
     };
 
     let res = match artifact.run(&mut host, init_name, &[Value::I64(amount as i64)]) {
@@ -873,15 +923,15 @@ pub fn invoke_receive<C: RunnableCode, Ctx: HasReceiveContext>(
     energy: u64,
 ) -> ExecResult<ReceiveResult> {
     let mut host = ReceiveHost {
-        energy:            InterpreterEnergy {
+        energy: InterpreterEnergy {
             energy,
         },
         activation_frames: MAX_ACTIVATION_FRAMES,
-        logs:              Logs::new(),
-        state:             State::new(Some(current_state)),
-        param:             &parameter,
-        receive_ctx:       &receive_ctx,
-        outcomes:          Outcome::new(),
+        logs: Logs::new(),
+        state: State::new(Some(current_state)),
+        param: &parameter,
+        receive_ctx,
+        outcomes: Outcome::new(),
     };
 
     let res = match artifact.run(&mut host, receive_name, &[Value::I64(amount as i64)]) {
@@ -1018,6 +1068,8 @@ pub fn invoke_receive_with_metering_from_source<Ctx: HasReceiveContext>(
 pub struct TrapHost;
 
 impl<I> machine::Host<I> for TrapHost {
+    type Interrupt = NoInterrupt;
+
     fn tick_initial_memory(&mut self, _num_pages: u32) -> machine::RunResult<()> { Ok(()) }
 
     fn call(
@@ -1093,6 +1145,8 @@ impl std::fmt::Display for ReportError {
 }
 
 impl machine::Host<ArtifactNamedImport> for TestHost {
+    type Interrupt = NoInterrupt;
+
     fn tick_initial_memory(&mut self, _num_pages: u32) -> machine::RunResult<()> {
         // The test host does not count energy.
         Ok(())

--- a/wasm-chain-integration/src/resumption.rs
+++ b/wasm-chain-integration/src/resumption.rs
@@ -1,0 +1,20 @@
+use crate::{ExecResult, ProcessedImports};
+use wasm_transform::{
+    artifact::OwnedArtifact,
+    machine::{ExecutionOutcome, Host, RunConfig},
+};
+
+/// Interrupted state of the computation that may be resumed.
+pub struct InterruptedState<H> {
+    pub(crate) host:     H,
+    pub(crate) artifact: OwnedArtifact<ProcessedImports>,
+    pub(crate) config:   RunConfig,
+}
+
+impl<H: Host<ProcessedImports>> InterruptedState<H> {
+    /// Resume the suspended computation.
+    pub fn resume(mut self) -> ExecResult<ExecutionOutcome<H::Interrupt>> {
+        let host = &mut self.host;
+        self.artifact.run_config(host, self.config)
+    }
+}

--- a/wasm-test/Cargo.lock
+++ b/wasm-test/Cargo.lock
@@ -139,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,19 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -327,10 +346,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -525,6 +559,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
+ "derive_more",
  "leb128",
  "num_enum",
 ]

--- a/wasm-test/src/main.rs
+++ b/wasm-test/src/main.rs
@@ -34,6 +34,8 @@ impl std::fmt::Display for HostCallError {
 }
 
 impl Host<ArtifactNamedImport> for TrapHost {
+    type Interrupt = NoInterrupt;
+
     fn tick_initial_memory(&mut self, _num_pages: u32) -> RunResult<()> { Ok(()) }
 
     fn call(
@@ -55,6 +57,8 @@ struct MeteringHost {
 }
 
 impl Host<ArtifactNamedImport> for MeteringHost {
+    type Interrupt = NoInterrupt;
+
     fn tick_initial_memory(&mut self, _num_pages: u32) -> RunResult<()> { Ok(()) }
 
     fn call(

--- a/wasm-transform/Cargo.toml
+++ b/wasm-transform/Cargo.toml
@@ -13,6 +13,7 @@ fuzz-coverage = []
 leb128 = "0.2.4"
 anyhow = "1.0.33"
 num_enum = "0.5"
+derive_more = "0.99"
 
 
 [dependencies.concordium-contracts-common]

--- a/wasm-transform/src/artifact.rs
+++ b/wasm-transform/src/artifact.rs
@@ -349,6 +349,15 @@ impl<'a> RunnableCode for CompiledFunctionBytes<'a> {
 
 /// A parsed Wasm module. This no longer has custom sections since they are not
 /// needed for further processing.
+/// The type parameter `ImportFunc` is instantiated with the representation of
+/// host functions. To efficiently and relatively safely execute the module we
+/// preprocess imported functions into an enum. However for testing we sometimes
+/// just use raw imports. This type parameter allows us flexibility.
+/// The type parameter `RunnableCode` is used to allow flexibility in code
+/// representation. For testing uses it is convenient that the type is
+/// "owned", in the sense of it being a vector of instructions. For efficient
+/// execution, and to avoid deserialization, the code is represented as a byte
+/// array (i.e., as as slice of bytes `&[u8]`) when we execute it on the node.
 #[derive(Debug, Clone)]
 pub struct Artifact<ImportFunc, CompiledCode> {
     /// Imports by (module name, item name).

--- a/wasm-transform/src/artifact.rs
+++ b/wasm-transform/src/artifact.rs
@@ -214,7 +214,7 @@ pub trait TryFromImport: Sized {
 }
 
 /// An example of a processed import with minimal processing. Useful for testing
-/// an experimenting, but not for efficient execution.
+/// and experimenting, but not for efficient execution.
 #[derive(Debug, Clone, Display)]
 #[display(fmt = "{}.{}", mod_name, item_name)]
 pub struct ArtifactNamedImport {

--- a/wasm-transform/src/machine.rs
+++ b/wasm-transform/src/machine.rs
@@ -459,23 +459,30 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
         self.run_config(host, config)
     }
 
-    fn run_config<'a, Interrupt>(
+    pub fn run_config<'a, Interrupt>(
         &'a self,
         host: &mut impl Host<I, Interrupt>,
-        mut config: RunConfig<'a>,
+        config: RunConfig<'a>,
     ) -> RunResult<ExecutionOutcome<'a, Interrupt>> {
-        let pc = &mut config.pc;
-        let instructions = &mut config.instructions;
-        let stack = &mut config.stack;
-        let memory = &mut config.memory;
-        let return_type = &mut config.return_type;
-        let function_frames = &mut config.function_frames;
-        let locals_base = &mut config.locals_base;
-        let globals = &mut config.globals;
-        let max_memory = config.max_memory; // this does not change during execution.
+        // we deliberately deconstruct the struct here instead of having mutable
+        // references to fields here to improve performance. On some benchmarks
+        // instruction execution is 30% slower if we keep references to the config
+        // struct instead of deconstructing it here. Why that is I don't know, but it
+        // likely has to do with memory layout.
+        let RunConfig {
+            mut pc,
+            mut instructions,
+            mut function_frames,
+            mut return_type,
+            mut memory,
+            mut stack,
+            mut locals_base,
+            mut globals,
+            max_memory,
+        } = config;
         'outer: loop {
-            let instr = instructions[*pc];
-            *pc += 1;
+            let instr = instructions[pc];
+            pc += 1;
             // FIXME: The unsafe here is a bit wrong, but it is much faster than using
             // InternalOpcode::try_from(instr). About 25% faster on a fibonacci test.
             // The ensure here guarantees that the transmute is safe, provided that
@@ -486,83 +493,83 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                 // InternalOpcode::try_from(instr)? {
                 InternalOpcode::Unreachable => bail!("Unreachable."),
                 InternalOpcode::If => {
-                    let else_target = get_u32(instructions, pc);
+                    let else_target = get_u32(instructions, &mut pc);
                     let top = stack.pop();
                     if unsafe { top.short } == 0 {
                         // jump to the else branch.
-                        *pc = else_target as usize;
+                        pc = else_target as usize;
                     } // else do nothing and start executing the if branch
                 }
                 InternalOpcode::Br => {
                     // we could optimize this for the common case of jumping to end/beginning of a
                     // current block.
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     stack.set_pos(stack.size() - diff as usize);
-                    *pc = target as usize;
+                    pc = target as usize;
                 }
                 InternalOpcode::BrCarry => {
                     let cur_size = stack.size();
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     let top = stack.pop();
                     stack.set_pos(cur_size - diff as usize);
                     stack.push(top);
-                    *pc = target as usize;
+                    pc = target as usize;
                 }
                 InternalOpcode::BrIf => {
                     // we could optimize this for the common case of jumping to end/beginning of a
                     // current block.
                     let cur_size = stack.size();
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     let top = stack.pop();
                     if unsafe { top.short } != 0 {
                         stack.set_pos(cur_size - diff as usize);
-                        *pc = target as usize;
+                        pc = target as usize;
                     } // else do nothing
                 }
                 InternalOpcode::BrIfCarry => {
                     let cur_size = stack.size();
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     let top = stack.pop();
                     if unsafe { top.short } != 0 {
                         let top = stack.pop();
                         stack.set_pos(cur_size - diff as usize);
                         stack.push(top);
-                        *pc = target as usize;
+                        pc = target as usize;
                     } // else do nothing
                 }
                 InternalOpcode::BrTable => {
                     let cur_size = stack.size();
                     let top = stack.pop();
-                    let num_labels = get_u16(instructions, pc);
+                    let num_labels = get_u16(instructions, &mut pc);
                     let top: u32 = unsafe { top.short } as u32;
                     if top < u32::from(num_labels) {
-                        *pc += (top as usize + 1) * 8; // the +1 is for the
-                                                       // default branch.
+                        pc += (top as usize + 1) * 8; // the +1 is for the
+                                                      // default branch.
                     } // else use default branch
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     stack.set_pos(cur_size - diff as usize);
-                    *pc = target as usize;
+                    pc = target as usize;
                 }
                 InternalOpcode::BrTableCarry => {
                     let cur_size = stack.size();
                     let top = stack.pop();
-                    let num_labels = get_u16(instructions, pc);
+                    let num_labels = get_u16(instructions, &mut pc);
                     let top: u32 = unsafe { top.short } as u32;
                     if top < u32::from(num_labels) {
-                        *pc += (top as usize + 1) * 8; // the +1 is for the
-                                                       // default branch.
+                        pc += (top as usize + 1) * 8; // the +1 is for the
+                                                      // default branch.
                     } // else use default branch
-                    let diff = get_u32(instructions, pc);
-                    let target = get_u32(instructions, pc);
+                    let diff = get_u32(instructions, &mut pc);
+                    let target = get_u32(instructions, &mut pc);
                     let top = stack.pop();
                     stack.set_pos(cur_size - diff as usize);
                     stack.push(top);
-                    *pc = target as usize;
+                    pc = target as usize;
                 }
                 InternalOpcode::Return => {
                     if let Some(top_frame) = function_frames.pop() {
@@ -573,10 +580,10 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                         } else {
                             stack.set_pos(top_frame.height);
                         }
-                        *pc = top_frame.pc;
-                        *instructions = top_frame.instructions;
-                        *return_type = top_frame.return_type;
-                        *locals_base = top_frame.locals_base;
+                        pc = top_frame.pc;
+                        instructions = top_frame.instructions;
+                        return_type = top_frame.return_type;
+                        locals_base = top_frame.locals_base;
                     } else {
                         break 'outer;
                     }
@@ -587,14 +594,28 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                     // overflow.
                     // 2. Manage storage of intermediate state
                     // ourselves. This means we have to store the state of execution, which is
-                    // stored in the config structure.
-                    let idx = get_u32(instructions, pc);
+                    // stored in the config structure. We handle synchronous calls by the host
+                    // function interrupting execution of the current
+                    // function/module. The host will then handle resumption.
+                    // If the host function returns Ok(None) then the meaning of it is that
+                    // execution should resume as normal.
+                    let idx = get_u32(instructions, &mut pc);
                     if let Some(f) = self.imports.get(idx as usize) {
                         // we are calling an imported function, handle the call directly.
-                        if let Some(reason) = host.call(f, memory, stack)? {
+                        if let Some(reason) = host.call(f, &mut memory, &mut stack)? {
                             return Ok(ExecutionOutcome::Interrupted {
                                 reason,
-                                state: config,
+                                state: RunConfig {
+                                    pc,
+                                    instructions,
+                                    function_frames,
+                                    return_type,
+                                    memory,
+                                    stack,
+                                    locals_base,
+                                    globals,
+                                    max_memory,
+                                },
                             });
                         }
                     } else {
@@ -603,13 +624,13 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                             .get(idx as usize - self.imports.len())
                             .ok_or_else(|| anyhow!("Accessing non-existent code."))?;
                         let current_frame = FunctionState {
-                            pc: *pc,
+                            pc,
                             instructions,
-                            locals_base: *locals_base,
+                            locals_base,
                             height: stack.size() - f.num_params() as usize,
-                            return_type: *return_type,
+                            return_type,
                         };
-                        *locals_base = current_frame.height;
+                        locals_base = current_frame.height;
                         function_frames.push(current_frame);
                         for ty in f.locals() {
                             match ty {
@@ -617,13 +638,13 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                                 ValueType::I64 => stack.push(StackValue::from(0u64)),
                             }
                         }
-                        *instructions = f.code();
-                        *pc = 0;
-                        *return_type = f.return_type();
+                        instructions = f.code();
+                        pc = 0;
+                        return_type = f.return_type();
                     }
                 }
                 InternalOpcode::CallIndirect => {
-                    let ty_idx = get_u32(instructions, pc);
+                    let ty_idx = get_u32(instructions, &mut pc);
                     let ty = self
                         .ty
                         .get(ty_idx as usize)
@@ -635,10 +656,20 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                             let ty_actual = f.ty();
                             // call imported function.
                             ensure!(ty_actual == ty, "Actual type different from expected.");
-                            if let Some(reason) = host.call(f, memory, stack)? {
+                            if let Some(reason) = host.call(f, &mut memory, &mut stack)? {
                                 return Ok(ExecutionOutcome::Interrupted {
                                     reason,
-                                    state: config,
+                                    state: RunConfig {
+                                        pc,
+                                        instructions,
+                                        function_frames,
+                                        return_type,
+                                        memory,
+                                        stack,
+                                        locals_base,
+                                        globals,
+                                        max_memory,
+                                    },
                                 });
                             }
                         } else {
@@ -656,13 +687,13 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                             );
                             // FIXME: Remove duplication.
                             let current_frame = FunctionState {
-                                pc: *pc,
+                                pc,
                                 instructions,
-                                locals_base: *locals_base,
+                                locals_base,
                                 height: stack.size() - f.num_params() as usize,
-                                return_type: *return_type,
+                                return_type,
                             };
-                            *locals_base = current_frame.height;
+                            locals_base = current_frame.height;
                             function_frames.push(current_frame);
                             for ty in f.locals() {
                                 match ty {
@@ -674,9 +705,9 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                                     }),
                                 }
                             }
-                            *instructions = f.code();
-                            *pc = 0;
-                            *return_type = f.return_type();
+                            instructions = f.code();
+                            pc = 0;
+                            return_type = f.return_type();
                         }
                     } else {
                         bail!("Calling undefined function {}.", idx) // trap
@@ -693,130 +724,130 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                     } // else t1 remains on the top of the stack.
                 }
                 InternalOpcode::LocalGet => {
-                    let idx = get_u16(instructions, pc);
-                    let val = stack.stack[*locals_base + idx as usize];
+                    let idx = get_u16(instructions, &mut pc);
+                    let val = stack.stack[locals_base + idx as usize];
                     stack.push(val)
                 }
                 InternalOpcode::LocalSet => {
-                    let idx = get_u16(instructions, pc);
+                    let idx = get_u16(instructions, &mut pc);
                     let top = stack.pop();
-                    stack.stack[*locals_base + idx as usize] = top
+                    stack.stack[locals_base + idx as usize] = top
                 }
                 InternalOpcode::LocalTee => {
-                    let idx = get_u16(instructions, pc);
+                    let idx = get_u16(instructions, &mut pc);
                     let top = stack.peek();
-                    stack.stack[*locals_base + idx as usize] = top
+                    stack.stack[locals_base + idx as usize] = top
                 }
                 InternalOpcode::GlobalGet => {
-                    let idx = get_u16(instructions, pc);
+                    let idx = get_u16(instructions, &mut pc);
                     stack.push(globals[idx as usize])
                 }
                 InternalOpcode::GlobalSet => {
-                    let idx = get_u16(instructions, pc);
+                    let idx = get_u16(instructions, &mut pc);
                     let top = stack.pop();
                     globals[idx as usize] = top
                 }
                 InternalOpcode::I32Load => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i32(&memory, pos)?;
                     stack.push(StackValue::from(val))
                 }
                 InternalOpcode::I64Load => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i64(&memory, pos)?;
                     stack.push(StackValue::from(val))
                 }
                 InternalOpcode::I32Load8S => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i8(&memory, pos)?;
                     stack.push(StackValue::from(val as i32))
                 }
                 InternalOpcode::I32Load8U => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_u8(&memory, pos)?;
                     stack.push(StackValue::from(val as i32))
                 }
                 InternalOpcode::I32Load16S => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i16(&memory, pos)?;
                     stack.push(StackValue::from(val as i32))
                 }
                 InternalOpcode::I32Load16U => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_u16(&memory, pos)?;
                     stack.push(StackValue::from(val as i32))
                 }
                 InternalOpcode::I64Load8S => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i8(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I64Load8U => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_u8(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I64Load16S => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i16(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I64Load16U => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_u16(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I64Load32S => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_i32(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I64Load32U => {
-                    let pos = get_memory_pos(instructions, stack, pc)?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
                     let val = read_u32(&memory, pos)?;
                     stack.push(StackValue::from(val as i64))
                 }
                 InternalOpcode::I32Store => {
                     let val = stack.pop();
                     let val = unsafe { val.short };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes())?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes())?;
                 }
                 InternalOpcode::I64Store => {
                     let val = stack.pop();
                     let val = unsafe { val.long };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes())?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes())?;
                 }
                 InternalOpcode::I32Store8 => {
                     let val = stack.pop();
                     let val = unsafe { val.short };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes()[..1])?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes()[..1])?;
                 }
                 InternalOpcode::I32Store16 => {
                     let val = stack.pop();
                     let val = unsafe { val.short };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes()[..2])?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes()[..2])?;
                 }
                 InternalOpcode::I64Store8 => {
                     let val = stack.pop();
                     let val = unsafe { val.long };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes()[..1])?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes()[..1])?;
                 }
                 InternalOpcode::I64Store16 => {
                     let val = stack.pop();
                     let val = unsafe { val.long };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes()[..2])?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes()[..2])?;
                 }
                 InternalOpcode::I64Store32 => {
                     let val = stack.pop();
                     let val = unsafe { val.long };
-                    let pos = get_memory_pos(instructions, stack, pc)?;
-                    write_memory_at(memory, pos, &val.to_le_bytes()[..4])?;
+                    let pos = get_memory_pos(instructions, &mut stack, &mut pc)?;
+                    write_memory_at(&mut memory, pos, &val.to_le_bytes()[..4])?;
                 }
                 InternalOpcode::MemorySize => {
                     let l = memory.len() / PAGE_SIZE as usize;
@@ -836,11 +867,11 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                     }
                 }
                 InternalOpcode::I32Const => {
-                    let val = get_i32(instructions, pc);
+                    let val = get_i32(instructions, &mut pc);
                     stack.push(StackValue::from(val));
                 }
                 InternalOpcode::I64Const => {
-                    let val = get_u64(instructions, pc);
+                    let val = get_u64(instructions, &mut pc);
                     stack.push(StackValue::from(val as i64));
                 }
                 InternalOpcode::I32Eqz => {
@@ -853,34 +884,34 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                     };
                 }
                 InternalOpcode::I32Eq => {
-                    binary_i32(stack, |left, right| (left == right) as i32);
+                    binary_i32(&mut stack, |left, right| (left == right) as i32);
                 }
                 InternalOpcode::I32Ne => {
-                    binary_i32(stack, |left, right| (left != right) as i32);
+                    binary_i32(&mut stack, |left, right| (left != right) as i32);
                 }
                 InternalOpcode::I32LtS => {
-                    binary_i32(stack, |left, right| (left < right) as i32);
+                    binary_i32(&mut stack, |left, right| (left < right) as i32);
                 }
                 InternalOpcode::I32LtU => {
-                    binary_i32(stack, |left, right| ((left as u32) < (right as u32)) as i32);
+                    binary_i32(&mut stack, |left, right| ((left as u32) < (right as u32)) as i32);
                 }
                 InternalOpcode::I32GtS => {
-                    binary_i32(stack, |left, right| (left > right) as i32);
+                    binary_i32(&mut stack, |left, right| (left > right) as i32);
                 }
                 InternalOpcode::I32GtU => {
-                    binary_i32(stack, |left, right| ((left as u32) > (right as u32)) as i32);
+                    binary_i32(&mut stack, |left, right| ((left as u32) > (right as u32)) as i32);
                 }
                 InternalOpcode::I32LeS => {
-                    binary_i32(stack, |left, right| (left <= right) as i32);
+                    binary_i32(&mut stack, |left, right| (left <= right) as i32);
                 }
                 InternalOpcode::I32LeU => {
-                    binary_i32(stack, |left, right| ((left as u32) <= (right as u32)) as i32);
+                    binary_i32(&mut stack, |left, right| ((left as u32) <= (right as u32)) as i32);
                 }
                 InternalOpcode::I32GeS => {
-                    binary_i32(stack, |left, right| (left >= right) as i32);
+                    binary_i32(&mut stack, |left, right| (left >= right) as i32);
                 }
                 InternalOpcode::I32GeU => {
-                    binary_i32(stack, |left, right| ((left as u32) >= (right as u32)) as i32);
+                    binary_i32(&mut stack, |left, right| ((left as u32) >= (right as u32)) as i32);
                 }
                 InternalOpcode::I64Eqz => {
                     let top = stack.peek_mut();
@@ -892,150 +923,158 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
                     };
                 }
                 InternalOpcode::I64Eq => {
-                    binary_i64_test(stack, |left, right| (left == right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left == right) as i32);
                 }
                 InternalOpcode::I64Ne => {
-                    binary_i64_test(stack, |left, right| (left != right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left != right) as i32);
                 }
                 InternalOpcode::I64LtS => {
-                    binary_i64_test(stack, |left, right| (left < right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left < right) as i32);
                 }
                 InternalOpcode::I64LtU => {
-                    binary_i64_test(stack, |left, right| ((left as u64) < (right as u64)) as i32);
+                    binary_i64_test(&mut stack, |left, right| {
+                        ((left as u64) < (right as u64)) as i32
+                    });
                 }
                 InternalOpcode::I64GtS => {
-                    binary_i64_test(stack, |left, right| (left > right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left > right) as i32);
                 }
                 InternalOpcode::I64GtU => {
-                    binary_i64_test(stack, |left, right| ((left as u64) > (right as u64)) as i32);
+                    binary_i64_test(&mut stack, |left, right| {
+                        ((left as u64) > (right as u64)) as i32
+                    });
                 }
                 InternalOpcode::I64LeS => {
-                    binary_i64_test(stack, |left, right| (left <= right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left <= right) as i32);
                 }
                 InternalOpcode::I64LeU => {
-                    binary_i64_test(stack, |left, right| ((left as u64) <= (right as u64)) as i32);
+                    binary_i64_test(&mut stack, |left, right| {
+                        ((left as u64) <= (right as u64)) as i32
+                    });
                 }
                 InternalOpcode::I64GeS => {
-                    binary_i64_test(stack, |left, right| (left >= right) as i32);
+                    binary_i64_test(&mut stack, |left, right| (left >= right) as i32);
                 }
                 InternalOpcode::I64GeU => {
-                    binary_i64_test(stack, |left, right| ((left as u64) >= (right as u64)) as i32);
+                    binary_i64_test(&mut stack, |left, right| {
+                        ((left as u64) >= (right as u64)) as i32
+                    });
                 }
                 InternalOpcode::I32Clz => {
-                    unary_i32(stack, |x| x.leading_zeros() as i32);
+                    unary_i32(&mut stack, |x| x.leading_zeros() as i32);
                 }
                 InternalOpcode::I32Ctz => {
-                    unary_i32(stack, |x| x.trailing_zeros() as i32);
+                    unary_i32(&mut stack, |x| x.trailing_zeros() as i32);
                 }
                 InternalOpcode::I32Popcnt => {
-                    unary_i32(stack, |x| x.count_ones() as i32);
+                    unary_i32(&mut stack, |x| x.count_ones() as i32);
                 }
                 InternalOpcode::I32Add => {
-                    binary_i32(stack, |x, y| x.wrapping_add(y));
+                    binary_i32(&mut stack, |x, y| x.wrapping_add(y));
                 }
                 InternalOpcode::I32Sub => {
-                    binary_i32(stack, |x, y| x.wrapping_sub(y));
+                    binary_i32(&mut stack, |x, y| x.wrapping_sub(y));
                 }
                 InternalOpcode::I32Mul => {
-                    binary_i32(stack, |x, y| x.wrapping_mul(y));
+                    binary_i32(&mut stack, |x, y| x.wrapping_mul(y));
                 }
                 InternalOpcode::I32DivS => {
-                    binary_i32_partial(stack, |x, y| x.checked_div(y))?;
+                    binary_i32_partial(&mut stack, |x, y| x.checked_div(y))?;
                 }
                 InternalOpcode::I32DivU => {
-                    binary_i32_partial(stack, |x, y| {
+                    binary_i32_partial(&mut stack, |x, y| {
                         (x as u32).checked_div(y as u32).map(|x| x as i32)
                     })?;
                 }
                 InternalOpcode::I32RemS => {
-                    binary_i32_partial(stack, |x, y| x.checked_rem(y))?;
+                    binary_i32_partial(&mut stack, |x, y| x.checked_rem(y))?;
                 }
                 InternalOpcode::I32RemU => {
-                    binary_i32_partial(stack, |x, y| {
+                    binary_i32_partial(&mut stack, |x, y| {
                         (x as u32).checked_rem(y as u32).map(|x| x as i32)
                     })?;
                 }
                 InternalOpcode::I32And => {
-                    binary_i32(stack, |x, y| x & y);
+                    binary_i32(&mut stack, |x, y| x & y);
                 }
                 InternalOpcode::I32Or => {
-                    binary_i32(stack, |x, y| x | y);
+                    binary_i32(&mut stack, |x, y| x | y);
                 }
                 InternalOpcode::I32Xor => {
-                    binary_i32(stack, |x, y| x ^ y);
+                    binary_i32(&mut stack, |x, y| x ^ y);
                 }
                 InternalOpcode::I32Shl => {
-                    binary_i32(stack, |x, y| x << (y as u32 % 32));
+                    binary_i32(&mut stack, |x, y| x << (y as u32 % 32));
                 }
                 InternalOpcode::I32ShrS => {
-                    binary_i32(stack, |x, y| x >> (y as u32 % 32));
+                    binary_i32(&mut stack, |x, y| x >> (y as u32 % 32));
                 }
                 InternalOpcode::I32ShrU => {
-                    binary_i32(stack, |x, y| ((x as u32) >> (y as u32 % 32)) as i32);
+                    binary_i32(&mut stack, |x, y| ((x as u32) >> (y as u32 % 32)) as i32);
                 }
                 InternalOpcode::I32Rotl => {
-                    binary_i32(stack, |x, y| x.rotate_left(y as u32 % 32));
+                    binary_i32(&mut stack, |x, y| x.rotate_left(y as u32 % 32));
                 }
                 InternalOpcode::I32Rotr => {
-                    binary_i32(stack, |x, y| x.rotate_right(y as u32 % 32));
+                    binary_i32(&mut stack, |x, y| x.rotate_right(y as u32 % 32));
                 }
                 InternalOpcode::I64Clz => {
-                    unary_i64(stack, |x| x.leading_zeros() as i64);
+                    unary_i64(&mut stack, |x| x.leading_zeros() as i64);
                 }
                 InternalOpcode::I64Ctz => {
-                    unary_i64(stack, |x| x.trailing_zeros() as i64);
+                    unary_i64(&mut stack, |x| x.trailing_zeros() as i64);
                 }
                 InternalOpcode::I64Popcnt => {
-                    unary_i64(stack, |x| x.count_ones() as i64);
+                    unary_i64(&mut stack, |x| x.count_ones() as i64);
                 }
                 InternalOpcode::I64Add => {
-                    binary_i64(stack, |x, y| x.wrapping_add(y));
+                    binary_i64(&mut stack, |x, y| x.wrapping_add(y));
                 }
                 InternalOpcode::I64Sub => {
-                    binary_i64(stack, |x, y| x.wrapping_sub(y));
+                    binary_i64(&mut stack, |x, y| x.wrapping_sub(y));
                 }
                 InternalOpcode::I64Mul => {
-                    binary_i64(stack, |x, y| x.wrapping_mul(y));
+                    binary_i64(&mut stack, |x, y| x.wrapping_mul(y));
                 }
                 InternalOpcode::I64DivS => {
-                    binary_i64_partial(stack, |x, y| x.checked_div(y))?;
+                    binary_i64_partial(&mut stack, |x, y| x.checked_div(y))?;
                 }
                 InternalOpcode::I64DivU => {
-                    binary_i64_partial(stack, |x, y| {
+                    binary_i64_partial(&mut stack, |x, y| {
                         (x as u64).checked_div(y as u64).map(|x| x as i64)
                     })?;
                 }
                 InternalOpcode::I64RemS => {
-                    binary_i64_partial(stack, |x, y| x.checked_rem(y))?;
+                    binary_i64_partial(&mut stack, |x, y| x.checked_rem(y))?;
                 }
                 InternalOpcode::I64RemU => {
-                    binary_i64_partial(stack, |x, y| {
+                    binary_i64_partial(&mut stack, |x, y| {
                         (x as u64).checked_rem(y as u64).map(|x| x as i64)
                     })?;
                 }
                 InternalOpcode::I64And => {
-                    binary_i64(stack, |x, y| x & y);
+                    binary_i64(&mut stack, |x, y| x & y);
                 }
                 InternalOpcode::I64Or => {
-                    binary_i64(stack, |x, y| x | y);
+                    binary_i64(&mut stack, |x, y| x | y);
                 }
                 InternalOpcode::I64Xor => {
-                    binary_i64(stack, |x, y| x ^ y);
+                    binary_i64(&mut stack, |x, y| x ^ y);
                 }
                 InternalOpcode::I64Shl => {
-                    binary_i64(stack, |x, y| x << (y as u64 % 64));
+                    binary_i64(&mut stack, |x, y| x << (y as u64 % 64));
                 }
                 InternalOpcode::I64ShrS => {
-                    binary_i64(stack, |x, y| x >> (y as u64 % 64));
+                    binary_i64(&mut stack, |x, y| x >> (y as u64 % 64));
                 }
                 InternalOpcode::I64ShrU => {
-                    binary_i64(stack, |x, y| ((x as u64) >> (y as u64 % 64)) as i64);
+                    binary_i64(&mut stack, |x, y| ((x as u64) >> (y as u64 % 64)) as i64);
                 }
                 InternalOpcode::I64Rotl => {
-                    binary_i64(stack, |x, y| x.rotate_left((y as u64 % 64) as u32));
+                    binary_i64(&mut stack, |x, y| x.rotate_left((y as u64 % 64) as u32));
                 }
                 InternalOpcode::I64Rotr => {
-                    binary_i64(stack, |x, y| x.rotate_right((y as u64 % 64) as u32));
+                    binary_i64(&mut stack, |x, y| x.rotate_right((y as u64 % 64) as u32));
                 }
                 InternalOpcode::I32WrapI64 => {
                     let top = stack.peek_mut();
@@ -1055,24 +1094,24 @@ impl<I: TryFromImport, R: RunnableCode> Artifact<I, R> {
             }
         }
 
-        match *return_type {
+        match return_type {
             BlockType::ValueType(ValueType::I32) => {
                 let val = stack.pop();
                 Ok(ExecutionOutcome::Success {
                     result: Some(Value::I32(unsafe { val.short })),
-                    memory: std::mem::take(memory),
+                    memory,
                 })
             }
             BlockType::ValueType(ValueType::I64) => {
                 let val = stack.pop();
                 Ok(ExecutionOutcome::Success {
                     result: Some(Value::I64(unsafe { val.long })),
-                    memory: std::mem::take(memory),
+                    memory,
                 })
             }
             BlockType::EmptyType => Ok(ExecutionOutcome::Success {
                 result: None,
-                memory: std::mem::take(memory),
+                memory,
             }),
         }
     }

--- a/wasm-transform/src/types.rs
+++ b/wasm-transform/src/types.rs
@@ -7,15 +7,16 @@
 //! guaranteed automatically by the AST definition of the Module, and the
 //! parsing functions.
 
+use anyhow::bail;
+use derive_more::{Display, From};
 use std::{convert::TryFrom, rc::Rc};
 
-use anyhow::bail;
-
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
-/// A webassembly Name. We choose to have it be an owned value rather than ar
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Display)]
+/// A webassembly Name. We choose to have it be an owned value rather than a
 /// reference into the original module. Names are also used in the parsed AST,
 /// and we don't want to retain references to the original bytes just because of
 /// a few names.
+#[display(fmt = "{}", name)]
 pub struct Name {
     /// Names in Wasm are utf8 encoded.
     pub name: String,
@@ -23,11 +24,6 @@ pub struct Name {
 
 impl AsRef<str> for Name {
     fn as_ref(&self) -> &str { &self.name }
-}
-
-/// The Display just uses the Display instance for the underlying String.
-impl std::fmt::Display for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.name.fmt(f) }
 }
 
 impl<'a> From<&'a str> for Name {
@@ -435,17 +431,9 @@ pub type InstrSeq = Vec<OpCode>;
 
 /// An expression is a sequence of instructions followed by the "end" delimiter,
 /// which is also present in the binary format (see 5.4.6).
-#[derive(Debug, Default)]
+#[derive(Debug, Default, From)]
 pub struct Expression {
     pub instrs: InstrSeq,
-}
-
-impl From<InstrSeq> for Expression {
-    fn from(instrs: InstrSeq) -> Self {
-        Expression {
-            instrs,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Purpose

This introduces the ability for a host function to signal that the current
exection should be interrupted and its state saved so that it can be resumed.

This will be needed to support synchronous view function calls but is its current form a self-contained change that does not change the semantics of the execution.

## Changes

- The host function may signal that an interrupt happened. The interpreter loop then terminates.
- Other updates are type corrections to account for this.
- There should be no observable changes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
