### PR TITLE
Adds display-state sub-command to cargo concordium.

### DIFF
--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +25,12 @@ name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -92,10 +107,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -127,7 +142,8 @@ dependencies = [
  "concordium-contracts-common",
  "criterion",
  "hex",
- "serde",
+ "ptree",
+ "serde 1.0.136",
  "serde_json",
  "structopt",
  "wasm-chain-integration",
@@ -140,7 +156,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513d17226888c7b8283ac02a1c1b0d8a9d4cbf6db65dfadb79f598f5d7966fe9"
 dependencies = [
- "serde",
+ "serde 1.0.136",
  "serde_derive",
  "toml",
 ]
@@ -168,7 +184,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
  "time",
  "winapi",
 ]
@@ -196,8 +212,24 @@ dependencies = [
  "chrono",
  "fnv",
  "hashbrown",
- "serde",
+ "serde 1.0.136",
  "serde_json",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static 1.4.0",
+ "nom",
+ "rust-ini",
+ "serde 1.0.136",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -227,13 +259,13 @@ dependencies = [
  "criterion-plot",
  "csv",
  "itertools",
- "lazy_static",
- "num-traits",
+ "lazy_static 1.4.0",
+ "num-traits 0.2.14",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
- "serde",
+ "serde 1.0.136",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -280,7 +312,7 @@ checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
 ]
@@ -292,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -315,7 +347,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -360,6 +392,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +422,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -394,6 +452,17 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -433,6 +502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +543,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -475,10 +560,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -505,13 +609,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -567,12 +691,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.14",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -638,6 +781,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "config",
+ "directories",
+ "petgraph",
+ "serde 1.0.136",
+ "serde-value",
+ "tint",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,8 +826,27 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -677,6 +855,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -691,6 +871,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc_version"
@@ -730,11 +916,39 @@ checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static 1.4.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -744,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -766,7 +980,7 @@ checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -799,6 +1013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
- "lazy_static",
+ "lazy_static 1.4.0",
  "structopt-derive",
 ]
 
@@ -880,12 +1100,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tint"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
+dependencies = [
+ "lazy_static 0.2.11",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
+ "serde 1.0.136",
  "serde_json",
 ]
 
@@ -910,7 +1139,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -983,7 +1212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
- "lazy_static",
+ "lazy_static 1.4.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1030,7 +1259,8 @@ dependencies = [
  "derive_more",
  "libc",
  "num_enum",
- "serde",
+ "ptree",
+ "serde 1.0.136",
  "sha2 0.10.2",
  "slab",
  "thiserror",
@@ -1089,3 +1319,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -16,6 +16,7 @@ serde_json="1.0.56"
 cargo_toml = "0.8.1"
 anyhow = "1.0.33"
 ansi_term = "0.12"
+ptree = "0.4"
 
 [features]
 
@@ -26,6 +27,7 @@ version = "0"
 [dependencies.wasm-chain-integration]
 version = "0.2"
 path = "../wasm-chain-integration/"
+features = ["display-state"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -59,7 +59,7 @@ pub fn build_contract(
     let schema = match version {
         utils::WasmVersion::V0 => {
             if build_schema.build() {
-                let schema = build_contract_schema(&cargo_args, utils::generate_contract_schema_v0)
+                let schema = build_contract_schema(cargo_args, utils::generate_contract_schema_v0)
                     .context("Could not build module schema.")?;
                 if build_schema.embed() {
                     schema_bytes = to_bytes(&schema);
@@ -77,7 +77,7 @@ pub fn build_contract(
         }
         utils::WasmVersion::V1 => {
             if build_schema.build() {
-                let schema = build_contract_schema(&cargo_args, utils::generate_contract_schema_v1)
+                let schema = build_contract_schema(cargo_args, utils::generate_contract_schema_v1)
                     .context("Could not build module schema.")?;
                 if build_schema.embed() {
                     schema_bytes = to_bytes(&schema);

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -10,7 +10,7 @@ use concordium_contracts_common::{
     schema::{Function, Type},
     to_bytes, Amount, OwnedReceiveName, Parameter,
 };
-use ptree::{TreeBuilder, print_tree_with, PrintConfig};
+use ptree::{print_tree_with, PrintConfig, TreeBuilder};
 use std::{
     fs::{self, File},
     io::Read,
@@ -41,15 +41,13 @@ enum Command {
         about = "Locally simulate invocation method of a smart contract and inspect the state."
     )]
     Run(Box<RunCommand>),
-    #[structopt(
-        name = "display-state",
-        about = "Display the contract state as a tree."
-    )]
+    #[structopt(name = "display-state", about = "Display the contract state as a tree.")]
     DisplayState {
         #[structopt(
             name = "state-bin",
             long = "state-bin",
-            help = "Path to the file with state that is to be displayed. The state must be for a V1 contract."
+            help = "Path to the file with state that is to be displayed. The state must be for a \
+                    V1 contract."
         )]
         state_bin_path: PathBuf,
     },
@@ -178,22 +176,22 @@ enum RunCommand {
             short = "c",
             help = "Name of the contract to instantiate."
         )]
-        contract_name: String,
+        contract_name:        String,
         #[structopt(
             name = "context",
             long = "context",
             short = "t",
             help = "Path to the init context file."
         )]
-        context:       Option<PathBuf>,
+        context:              Option<PathBuf>,
         #[structopt(
             name = "display-state",
             long = "display-state",
             help = "Pretty print the contract state at the end of execution."
         )]
-        should_display_state:   bool,
+        should_display_state: bool,
         #[structopt(flatten)]
-        runner:        Runner,
+        runner:               Runner,
     },
     #[structopt(name = "update", about = "Invoke a receive method of a module.")]
     Receive {
@@ -218,35 +216,35 @@ enum RunCommand {
             help = "File with existing state of the contract in JSON, requires a schema is \
                     present either embedded or using --schema."
         )]
-        state_json_path: Option<PathBuf>,
+        state_json_path:      Option<PathBuf>,
         #[structopt(
             name = "state-bin",
             long = "state-bin",
             help = "File with existing state of the contract in binary."
         )]
-        state_bin_path:  Option<PathBuf>,
+        state_bin_path:       Option<PathBuf>,
         #[structopt(
             name = "balance",
             long = "balance",
             help = "Balance on the contract at the time it is invoked. Overrides the balance in \
                     the receive context."
         )]
-        balance:         Option<u64>,
+        balance:              Option<u64>,
         #[structopt(
             name = "context",
             long = "context",
             short = "t",
             help = "Path to the receive context file."
         )]
-        context:         Option<PathBuf>,
+        context:              Option<PathBuf>,
         #[structopt(
             name = "display-state",
             long = "display-state",
             help = "Pretty print the contract state at the end of execution."
         )]
-        should_display_state:   bool,
+        should_display_state: bool,
         #[structopt(flatten)]
-        runner:          Runner,
+        runner:               Runner,
     },
 }
 
@@ -366,12 +364,15 @@ pub fn main() -> anyhow::Result<()> {
                 bold_style.paint(size)
             )
         }
-        Command::DisplayState { state_bin_path } => display_state_from_file(state_bin_path)?,
+        Command::DisplayState {
+            state_bin_path,
+        } => display_state_from_file(state_bin_path)?,
     };
     Ok(())
 }
 
-/// Loads the contract state from file and displays it as a tree by printing to stdout.
+/// Loads the contract state from file and displays it as a tree by printing to
+/// stdout.
 fn display_state_from_file(file_path: PathBuf) -> anyhow::Result<()> {
     let file = File::open(&file_path)
         .with_context(|| format!("Could not read state file {}.", file_path.display()))?;
@@ -389,8 +390,9 @@ fn display_state(state: &v1::trie::PersistentState) -> Result<(), anyhow::Error>
     let mut tree_builder = TreeBuilder::new("StateRoot".into());
     state.display_tree(&mut tree_builder, &mut loader);
     let tree = tree_builder.build();
-    // We don't want to depend on some global config as it opens up for all sorts of 
-    // corner-case bugs since we are not in control and thus inconsistent user experience.
+    // We don't want to depend on some global config as it opens up for all sorts of
+    // corner-case bugs since we are not in control and thus inconsistent user
+    // experience.
     let config = PrintConfig::default();
     print_tree_with(&tree, &config).context("Could not print the state as a tree.")
 }

--- a/wasm-chain-integration/Cargo.lock
+++ b/wasm-chain-integration/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,12 @@ checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -101,10 +116,10 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -148,7 +163,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
  "time",
  "winapi",
 ]
@@ -172,8 +187,24 @@ dependencies = [
  "chrono",
  "fnv",
  "hashbrown",
- "serde",
+ "serde 1.0.136",
  "serde_json",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static 1.4.0",
+ "nom",
+ "rust-ini",
+ "serde 1.0.136",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -203,13 +234,13 @@ dependencies = [
  "criterion-plot",
  "csv",
  "itertools",
- "lazy_static",
- "num-traits",
+ "lazy_static 1.4.0",
+ "num-traits 0.2.14",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
- "serde",
+ "serde 1.0.136",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -256,7 +287,7 @@ checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "memoffset",
  "scopeguard",
 ]
@@ -268,7 +299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -291,7 +322,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -347,6 +378,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +418,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -467,6 +524,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -478,10 +541,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -508,13 +590,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -570,12 +672,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.14",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -614,6 +735,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "ptree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "config",
+ "directories",
+ "petgraph",
+ "serde 1.0.136",
+ "serde-value",
+ "tint",
 ]
 
 [[package]]
@@ -675,8 +812,27 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -701,6 +857,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc_version"
@@ -740,11 +902,39 @@ checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static 1.4.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -754,7 +944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -776,7 +966,7 @@ checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -807,6 +997,12 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -860,12 +1056,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tint"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
+dependencies = [
+ "lazy_static 0.2.11",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
+ "serde 1.0.136",
  "serde_json",
 ]
 
@@ -890,7 +1095,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -951,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
- "lazy_static",
+ "lazy_static 1.4.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1000,8 +1205,9 @@ dependencies = [
  "derive_more",
  "libc",
  "num_enum",
+ "ptree",
  "quickcheck",
- "serde",
+ "serde 1.0.136",
  "sha2 0.10.2",
  "slab",
  "thiserror",
@@ -1095,3 +1301,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/wasm-chain-integration/Cargo.toml
+++ b/wasm-chain-integration/Cargo.toml
@@ -12,6 +12,7 @@ enable-ffi = []
 default=["enable-ffi"]
 fuzz = ["arbitrary", "wasm-smith", "wasmprinter"]
 fuzz-coverage = ["wasm-transform/fuzz-coverage"]
+display-state = ["ptree"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -25,6 +26,7 @@ thiserror = "1"
 byteorder = "1.4"
 tinyvec = {version = "1.5", features = ["alloc"]}
 slab = "0.4.5"
+ptree = { version = "0.4.0", optional = true }
 
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 wasm-smith = { git = "https://github.com/Concordium/wasm-tools.git", branch = "mra/fuzzing", optional = true }

--- a/wasm-chain-integration/src/v0/ffi.rs
+++ b/wasm-chain-integration/src/v0/ffi.rs
@@ -55,7 +55,8 @@ unsafe extern "C" fn call_init_v0(
         }
     });
     // do not drop the pointer, we are not the owner
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -112,7 +113,8 @@ unsafe extern "C" fn call_receive_v0(
         }
     });
     // do not drop the pointer, we are not the owner
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -208,7 +210,8 @@ unsafe extern "C" fn artifact_v0_to_bytes(
     *output_len = bytes.len() as size_t;
     let ptr = bytes.as_mut_ptr();
     std::mem::forget(bytes);
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     ptr
 }
 

--- a/wasm-chain-integration/src/v0/ffi.rs
+++ b/wasm-chain-integration/src/v0/ffi.rs
@@ -56,7 +56,9 @@ unsafe extern "C" fn call_init_v0(
     });
     // do not drop the pointer, we are not the owner
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -114,7 +116,9 @@ unsafe extern "C" fn call_receive_v0(
     });
     // do not drop the pointer, we are not the owner
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -211,7 +215,9 @@ unsafe extern "C" fn artifact_v0_to_bytes(
     let ptr = bytes.as_mut_ptr();
     std::mem::forget(bytes);
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     ptr
 }
 

--- a/wasm-chain-integration/src/v1/ffi.rs
+++ b/wasm-chain-integration/src/v1/ffi.rs
@@ -157,7 +157,8 @@ unsafe extern "C" fn call_init_v1(
         }
     });
     // do not drop the pointer, we are not the owner
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -292,7 +293,8 @@ unsafe extern "C" fn call_receive_v1(
         }
     });
     // do not drop the pointer, we are not the owner
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -532,7 +534,8 @@ unsafe extern "C" fn artifact_v1_to_bytes(
     *output_len = bytes.len() as size_t;
     let ptr = bytes.as_mut_ptr();
     std::mem::forget(bytes);
-    Arc::into_raw(artifact);
+    #[allow(unused_must_use)]
+    { Arc::into_raw(artifact); }
     ptr
 }
 

--- a/wasm-chain-integration/src/v1/ffi.rs
+++ b/wasm-chain-integration/src/v1/ffi.rs
@@ -158,7 +158,9 @@ unsafe extern "C" fn call_init_v1(
     });
     // do not drop the pointer, we are not the owner
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -294,7 +296,9 @@ unsafe extern "C" fn call_receive_v1(
     });
     // do not drop the pointer, we are not the owner
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     // and return the value
     res.unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -535,7 +539,9 @@ unsafe extern "C" fn artifact_v1_to_bytes(
     let ptr = bytes.as_mut_ptr();
     std::mem::forget(bytes);
     #[allow(unused_must_use)]
-    { Arc::into_raw(artifact); }
+    {
+        Arc::into_raw(artifact);
+    }
     ptr
 }
 

--- a/wasm-chain-integration/src/v1/mod.rs
+++ b/wasm-chain-integration/src/v1/mod.rs
@@ -439,7 +439,7 @@ mod host {
 
     pub fn state_iterator_key_size<'a, BackingStore: BackingStoreLoad>(
         stack: &mut machine::RuntimeStack,
-        energy: &mut InterpreterEnergy,
+        _energy: &mut InterpreterEnergy,
         state: &mut InstanceState<'a, BackingStore>,
     ) -> machine::RunResult<()> {
         // TODO: Verify cost below.

--- a/wasm-chain-integration/src/v1/trie/api.rs
+++ b/wasm-chain-integration/src/v1/trie/api.rs
@@ -3,6 +3,8 @@ use super::{
     types::*,
 };
 use byteorder::{ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "display-state")]
+use ptree::TreeBuilder;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 pub type Value = Vec<u8>;
@@ -90,6 +92,14 @@ impl PersistentState {
                 let borrowed = data.borrow();
                 Some(borrowed.data.get(loader))
             }
+        }
+    }
+
+    #[cfg(feature = "display-state")]
+    pub fn display_tree(&self, builder: &mut TreeBuilder, loader: &mut impl BackingStoreLoad) {
+        match self {
+            Self::Empty => {},
+            Self::Root(node) => node.data.display_tree(builder, loader),
         }
     }
 }

--- a/wasm-chain-integration/src/v1/trie/api.rs
+++ b/wasm-chain-integration/src/v1/trie/api.rs
@@ -98,7 +98,7 @@ impl PersistentState {
     #[cfg(feature = "display-state")]
     pub fn display_tree(&self, builder: &mut TreeBuilder, loader: &mut impl BackingStoreLoad) {
         match self {
-            Self::Empty => {},
+            Self::Empty => {}
             Self::Root(node) => node.data.display_tree(builder, loader),
         }
     }

--- a/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -14,10 +14,11 @@ use sha2::Digest;
 use slab::Slab;
 use std::{
     collections::HashMap,
+    fmt::{self, Debug, Display, Formatter, LowerHex},
     io::{Read, Write},
     iter::once,
     num::NonZeroU16,
-    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard}, fmt::{Debug, Display, Formatter, self, LowerHex},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
 /// Children of a node are sometimes stored in a [tinyvec::TinyVec]. This
@@ -780,9 +781,7 @@ struct Chunk<const N: usize> {
 }
 
 impl LowerHex for Chunk<4> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:x}", self.value)
-    }
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result { write!(f, "{:x}", self.value) }
 }
 
 impl<const N: usize> Chunk<N> {
@@ -1213,9 +1212,7 @@ impl<V: Loadable + Debug> Node<V> {
     #[cfg(feature = "display-state")]
     pub fn display_tree(&self, builder: &mut TreeBuilder, loader: &mut impl BackingStoreLoad) {
         let value = if let Some(ref value) = self.value {
-            value.borrow().data.use_value(loader, |value| {
-                format!(", value = {:?}", value)
-            })
+            value.borrow().data.use_value(loader, |value| format!(", value = {:?}", value))
         } else {
             String::new()
         };
@@ -1224,9 +1221,7 @@ impl<V: Loadable + Debug> Node<V> {
         for (key, node) in &self.children {
             builder.begin_child(format!("Child {:#x}", *key));
             let node = node.borrow();
-            let node = node.use_value(loader, |node| {
-              node.data.clone()
-            });
+            let node = node.use_value(loader, |node| node.data.clone());
             node.display_tree(builder, loader);
             builder.end_child();
         }

--- a/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -8,6 +8,8 @@
 //! `super::api` module, which is re-exported at the top-level.
 use super::types::*;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "display-state")]
+use ptree::TreeBuilder;
 use sha2::Digest;
 use slab::Slab;
 use std::{
@@ -15,7 +17,7 @@ use std::{
     io::{Read, Write},
     iter::once,
     num::NonZeroU16,
-    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard}, fmt::{Debug, Display, Formatter, self, LowerHex},
 };
 
 /// Children of a node are sometimes stored in a [tinyvec::TinyVec]. This
@@ -653,6 +655,21 @@ impl Stem {
     }
 }
 
+impl Display for Stem {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut stem_iter = self.iter();
+        if let Some(chunk) = stem_iter.next() {
+            write!(f, "0x{:x}", chunk)?;
+            while let Some(chunk) = stem_iter.next() {
+                write!(f, "{:x}", chunk)?
+            }
+        } else {
+            write!(f, "[]")?;
+        }
+        Ok(())
+    }
+}
+
 impl From<&[u8]> for Stem {
     #[inline(always)]
     fn from(data: &[u8]) -> Self {
@@ -760,6 +777,12 @@ impl<'a> StemIter<'a> {
 /// 8.
 struct Chunk<const N: usize> {
     value: u8,
+}
+
+impl LowerHex for Chunk<4> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:x}", self.value)
+    }
 }
 
 impl<const N: usize> Chunk<N> {
@@ -1165,7 +1188,7 @@ impl<V> Loadable for Node<V> {
     }
 }
 
-impl<V: Loadable> Node<V> {
+impl<V: Loadable + Debug> Node<V> {
     /// The entire tree in memory.
     pub fn cache<F: BackingStoreLoad>(&mut self, loader: &mut F) {
         if let Some(v) = self.value.as_mut() {
@@ -1184,6 +1207,28 @@ impl<V: Loadable> Node<V> {
             for c in node.data.children.iter() {
                 stack.push(c.1.clone());
             }
+        }
+    }
+
+    #[cfg(feature = "display-state")]
+    pub fn display_tree(&self, builder: &mut TreeBuilder, loader: &mut impl BackingStoreLoad) {
+        let value = if let Some(ref value) = self.value {
+            value.borrow().data.use_value(loader, |value| {
+                format!(", value = {:?}", value)
+            })
+        } else {
+            String::new()
+        };
+        let text = format!("Node (path = {}{})", self.path, value);
+        builder.add_empty_child(text);
+        for (key, node) in &self.children {
+            builder.begin_child(format!("Child {:#x}", *key));
+            let node = node.borrow();
+            let node = node.use_value(loader, |node| {
+              node.data.clone()
+            });
+            node.display_tree(builder, loader);
+            builder.end_child();
         }
     }
 }


### PR DESCRIPTION
## Purpose

This PR adds a new subcommand `display-state` to `cargo-concordium` to display the contract state as a tree on the console.

It also adds an `--display-state` option to `run update` subcommand to display the state.

## Changes

- Add a `DisplayTree` trait and relevant implementations
- Add an external dependency `ptree` to print the state as a tree.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.