### PR TITLE
Fixes #48: Double printing of warning messages during build with sche…

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
 ## Unreleased changes
+
 - Add support for V1 contract builds, testing, and execution.
 - The output of `cargo concordium build` is now versioned.
 - Support contracts written with Rust edition 2021.
+- Double printing of warning messages during build with `--schema-embed` is prevented.
 
 ## 1.1.1
+
 - Clarify that energy units used by `cargo-concordium` are "interpreter energy"
   and not the same as NRG.
 - Allow the user to only specify the necessary fields in the JSON context files

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -197,9 +197,7 @@ fn build_contract_with_cargo(
         .stderr(stdio())
         .output()
         .context("Could not use cargo build.")?;
-    if !result.status.success() {
-        anyhow::bail!("Compilation failed.")
-    }
+    anyhow::ensure!(result.status.success(), "Compilation failed.");
     Ok(())
 }
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -173,12 +173,20 @@ pub fn build_contract(
 // Build a contract and its schema if needed.
 // When `with-schema` is `true`, the contract is built with the schema.
 // when `quiet` is `true`, the output is suppressed.
-fn build_contract_with_cargo(cargo_args: &[String], with_schema: bool, quiet: bool) -> anyhow::Result<()> {
+fn build_contract_with_cargo(
+    cargo_args: &[String],
+    with_schema: bool,
+    quiet: bool,
+) -> anyhow::Result<()> {
     let mut cargo_args = cargo_args.to_vec();
     if with_schema {
         cargo_args.extend(["--features".into(), "concordium-std/build-schema".into()]);
     }
-    let stdio = if quiet { Stdio::null } else { Stdio::inherit };
+    let stdio = if quiet {
+        Stdio::null
+    } else {
+        Stdio::inherit
+    };
     let result = Command::new("cargo")
         .arg("build")
         .args(&["--target", "wasm32-unknown-unknown"])
@@ -189,9 +197,10 @@ fn build_contract_with_cargo(cargo_args: &[String], with_schema: bool, quiet: bo
         .stderr(stdio())
         .output()
         .context("Could not use cargo build.")?;
-    Ok(if !result.status.success() {
+    if !result.status.success() {
         anyhow::bail!("Compilation failed.")
-    })
+    }
+    Ok(())
 }
 
 /// Check that exports of module conform to the specification so that they will


### PR DESCRIPTION
…ma embedded

## Purpose

To prevent double printing of warning messages during build with schema embedded.

## Changes

Suppress the output of the second build.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
