### PR TITLE
Prepare for release 2.0.2 of cargo-concordium.

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-
-
-## Unreleased changes
+## 2.0.2
 
 - Support schema types for LEB128 and byte arrays.
 - Support schema modules which includes version information.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-concordium"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license-file = "../LICENSE-APACHE"


### PR DESCRIPTION
## Purpose

Bump version to 2.0.2 to prepare for release.