### PR TITLE
Bump the Rust version to 1.62, resolve clippy issues.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ on:
 
 env:
   # from concordium/rustfmt:0.17
-  RUST_FMT: nightly-2021-06-09-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.53
+  RUST_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
+  RUST_CLIPPY: 1.62
   TARGET: wasm32-unknown-unknown
 
 jobs:

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -21,7 +21,7 @@ use wasm_transform::{
     validate::validate_module,
 };
 
-fn to_snake_case(string: String) -> String { string.to_lowercase().replace("-", "_") }
+fn to_snake_case(string: String) -> String { string.to_lowercase().replace('-', "_") }
 
 #[derive(Debug, Clone, Copy)]
 pub enum SchemaBuildOptions {

--- a/cargo-concordium/windows-cargo-concordium.Jenkinsfile
+++ b/cargo-concordium/windows-cargo-concordium.Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                     fi   
 
                     # Set rust env
-                    rustup default 1.53-x86_64-pc-windows-gnu
+                    rustup default 1.62-x86_64-pc-windows-gnu
 
                     cd cargo-concordium
 

--- a/wasm-chain-integration/benches/trie_benches.rs
+++ b/wasm-chain-integration/benches/trie_benches.rs
@@ -63,7 +63,7 @@ fn make_mut_trie(words: &[Vec<u8>]) -> (MutableTrie, VecLoader) {
         inner: Vec::<u8>::new(),
     };
     for w in words {
-        node.insert(&mut loader, &w, (w.len() as u64).to_ne_bytes().into())
+        node.insert(&mut loader, w, (w.len() as u64).to_ne_bytes().into())
             .expect("No locks, so cannot fail.");
     }
     (node, loader)

--- a/wasm-chain-integration/src/lib.rs
+++ b/wasm-chain-integration/src/lib.rs
@@ -14,21 +14,21 @@ use derive_more::{Display, From, Into};
 /// the required one.
 ///
 /// # Example 1
-/// ```rust
-/// type_matches!(ty => [I32, I64]) 
+/// ```ignore
+/// type_matches!(ty => [I32, I64])
 /// ```
 /// The declared type `ty` must have **no return value** and parameters of types
 /// `I32` and `I64`
 ///
 /// # Example 2
-/// ```rust
-/// type_matches!(ty => []; I64) 
+/// ```ignore
+/// type_matches!(ty => []; I64)
 /// ```
 /// The declared type `ty` must have return type I64 and no arguments.
 ///
 /// # Example 3
-/// ```rust
-/// type_matches!(ty => [I32, I64, I32]; I64) 
+/// ```ignore
+/// type_matches!(ty => [I32, I64, I32]; I64)
 /// ```
 /// The declared type `ty` must have return type I64 and arguments of types
 /// `I32, I64, I32` in that order.

--- a/wasm-chain-integration/src/utils.rs
+++ b/wasm-chain-integration/src/utils.rs
@@ -375,10 +375,10 @@ pub fn get_embedded_schema_v0(bytes: &[u8]) -> ExecResult<schema::VersionedModul
 
     if let Some(cs) = schema_versioned_section {
         let module: schema::VersionedModuleSchema =
-            from_bytes(&cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
+            from_bytes(cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
         Ok(module)
     } else if let Some(cs) = schema_v1_section {
-        let module = from_bytes(&cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
+        let module = from_bytes(cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
         Ok(schema::VersionedModuleSchema::V0(module))
     } else {
         bail!("No schema found in the module")
@@ -405,10 +405,10 @@ pub fn get_embedded_schema_v1(bytes: &[u8]) -> ExecResult<schema::VersionedModul
 
     if let Some(cs) = schema_versioned_section {
         let module: schema::VersionedModuleSchema =
-            from_bytes(&cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
+            from_bytes(cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
         Ok(module)
     } else if let Some(cs) = schema_v2_section {
-        let module = from_bytes(&cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
+        let module = from_bytes(cs.contents).map_err(|_| anyhow!("Failed parsing schema"))?;
         Ok(schema::VersionedModuleSchema::V1(module))
     } else {
         bail!("No schema found in the module")

--- a/wasm-chain-integration/src/v0/ffi.rs
+++ b/wasm-chain-integration/src/v0/ffi.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn call_init_v0(
     // do not drop the pointer, we are not the owner
     let _ = Arc::into_raw(artifact);
     // and return the value
-    res.unwrap_or_else(|_| std::ptr::null_mut())
+    res.unwrap_or(std::ptr::null_mut())
 }
 
 #[no_mangle]
@@ -114,7 +114,7 @@ unsafe extern "C" fn call_receive_v0(
     // do not drop the pointer, we are not the owner
     let _ = Arc::into_raw(artifact);
     // and return the value
-    res.unwrap_or_else(|_| std::ptr::null_mut())
+    res.unwrap_or(std::ptr::null_mut())
 }
 
 #[no_mangle]
@@ -228,7 +228,7 @@ unsafe extern "C" fn artifact_v0_from_bytes(
     input_len: size_t,
 ) -> *const ArtifactV0 {
     let bytes = slice_from_c_bytes!(bytes_ptr, input_len as usize);
-    if let Ok(borrowed_artifact) = parse_artifact(&bytes) {
+    if let Ok(borrowed_artifact) = parse_artifact(bytes) {
         Arc::into_raw(Arc::new(borrowed_artifact.into()))
     } else {
         std::ptr::null()

--- a/wasm-chain-integration/src/v0/types.rs
+++ b/wasm-chain-integration/src/v0/types.rs
@@ -339,7 +339,7 @@ impl ReceiveResult {
                 let mut out = vec![2];
                 let state = &state.state;
                 out.extend_from_slice(&(state.len() as u32).to_be_bytes());
-                out.extend_from_slice(&state);
+                out.extend_from_slice(state);
                 out.extend_from_slice(&logs.to_bytes());
                 out.extend_from_slice(&(actions.len() as u32).to_be_bytes());
                 for a in actions.iter() {

--- a/wasm-chain-integration/src/v1/ffi.rs
+++ b/wasm-chain-integration/src/v1/ffi.rs
@@ -163,7 +163,7 @@ unsafe extern "C" fn call_init_v1(
     // do not drop the pointer, we are not the owner
     let _ = Arc::into_raw(artifact);
     // and return the value
-    res.unwrap_or_else(|_| std::ptr::null_mut())
+    res.unwrap_or(std::ptr::null_mut())
 }
 
 /// Invoke a receive function, updating the contract instance.
@@ -302,7 +302,7 @@ unsafe extern "C" fn call_receive_v1(
     // do not drop the pointer, we are not the owner
     let _ = Arc::into_raw(artifact);
     // and return the value
-    res.unwrap_or_else(|_| std::ptr::null_mut())
+    res.unwrap_or(std::ptr::null_mut())
 }
 
 #[no_mangle]
@@ -558,7 +558,7 @@ unsafe extern "C" fn artifact_v1_from_bytes(
     input_len: size_t,
 ) -> *const ArtifactV1 {
     let bytes = slice_from_c_bytes!(bytes_ptr, input_len as usize);
-    if let Ok(borrowed_artifact) = parse_artifact(&bytes) {
+    if let Ok(borrowed_artifact) = parse_artifact(bytes) {
         Arc::into_raw(Arc::new(borrowed_artifact.into()))
     } else {
         std::ptr::null()

--- a/wasm-chain-integration/src/v1/mod.rs
+++ b/wasm-chain-integration/src/v1/mod.rs
@@ -63,10 +63,10 @@ impl Interrupt {
                 out.write_all(&address.index.to_be_bytes())?;
                 out.write_all(&address.subindex.to_be_bytes())?;
                 out.write_all(&(parameter.len() as u16).to_be_bytes())?;
-                out.write_all(&parameter)?;
+                out.write_all(parameter)?;
                 let name_str: &str = name.as_entrypoint_name().into();
                 out.write_all(&(name_str.as_bytes().len() as u16).to_be_bytes())?;
-                out.write_all(&name_str.as_bytes())?;
+                out.write_all(name_str.as_bytes())?;
                 out.write_all(&amount.micro_ccd.to_be_bytes())?;
                 Ok(())
             }

--- a/wasm-chain-integration/src/v1/tests.rs
+++ b/wasm-chain-integration/src/v1/tests.rs
@@ -407,7 +407,7 @@ fn prop_iterators() {
         let mut removed_prefixes: Vec<&[u8]> = Vec::new();
         for (k, v) in &inputs {
             // make sure we don't try delete in suffixes of an already deleted prefix key.
-            if !removed_prefixes.iter().cloned().any(|x| k.starts_with(&x.to_vec())) {
+            if !removed_prefixes.iter().cloned().any(|x| k.starts_with(x)) {
                 let _entry = state
                     .lookup_entry(k)
                     .convert()

--- a/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -1500,7 +1500,7 @@ impl Hashed<Node> {
         backing_store: &mut S,
         buf: &mut W,
     ) -> StoreResult<()> {
-        buf.write_all(&self.hash.as_ref())?;
+        buf.write_all(self.hash.as_ref())?;
         self.data.store_update_buf(backing_store, buf)
     }
 }

--- a/wasm-chain-integration/src/v1/trie/tests.rs
+++ b/wasm-chain-integration/src/v1/trie/tests.rs
@@ -520,7 +520,7 @@ fn prop_iterator_locked_for_modification_generations() {
             }
             let mut locked_prefixes = Vec::new();
             for prefix in prefixes_to_lock {
-                if let Ok(Some(iterator)) = trie.iter(&mut loader, &prefix) {
+                if let Ok(Some(iterator)) = trie.iter(&mut loader, prefix) {
                     locked_prefixes.push(iterator);
                 }
             }

--- a/wasm-chain-integration/src/v1/trie/types.rs
+++ b/wasm-chain-integration/src/v1/trie/types.rs
@@ -224,7 +224,7 @@ impl<S> Loader<S> {
     }
 }
 
-impl<'a, A: AsRef<[u8]>> BackingStoreLoad for Loader<A> {
+impl<A: AsRef<[u8]>> BackingStoreLoad for Loader<A> {
     // with 28 the size of the type is 32 bytes, with 29 it is 40.
     // Since a normal vector takes 24 bytes always this seems a good compromise.
     type R = tinyvec::TinyVec<[u8; 28]>;

--- a/wasm-transform/src/artifact.rs
+++ b/wasm-transform/src/artifact.rs
@@ -344,7 +344,7 @@ impl<'a> RunnableCode for CompiledFunctionBytes<'a> {
     fn return_type(&self) -> BlockType { self.return_type }
 
     #[cfg_attr(not(feature = "fuzz-coverage"), inline(always))]
-    fn params(&self) -> &[ValueType] { &self.params }
+    fn params(&self) -> &[ValueType] { self.params }
 
     #[cfg_attr(not(feature = "fuzz-coverage"), inline(always))]
     fn num_locals(&self) -> u32 { self.num_locals }

--- a/wasm-transform/src/output.rs
+++ b/wasm-transform/src/output.rs
@@ -94,7 +94,7 @@ impl<'a, A: Output> Output for &'a [A] {
 }
 
 /// This implem
-impl<'a, A: Output> Output for Vec<A> {
+impl<A: Output> Output for Vec<A> {
     fn output(&self, out: &mut impl Write) -> OutResult<()> { self.as_slice().output(out) }
 }
 

--- a/wasm-transform/src/output.rs
+++ b/wasm-transform/src/output.rs
@@ -93,7 +93,8 @@ impl<'a, A: Output> Output for &'a [A] {
     }
 }
 
-/// This implem
+/// This implementation records the length of the vector as a u32 and then
+/// writes the elements in order.
 impl<A: Output> Output for Vec<A> {
     fn output(&self, out: &mut impl Write) -> OutResult<()> { self.as_slice().output(out) }
 }

--- a/wasm-transform/src/validate.rs
+++ b/wasm-transform/src/validate.rs
@@ -885,7 +885,7 @@ pub fn validate_module<'a>(
                     if let Some(ty) = ty.get(type_idx) {
                         let is_new = seen_imports.insert((&i.mod_name, &i.item_name));
                         ensure!(
-                            imp.validate_import_function(!is_new, &i.mod_name, &i.item_name, &ty),
+                            imp.validate_import_function(!is_new, &i.mod_name, &i.item_name, ty),
                             "Disallowed import."
                         );
                     } else {


### PR DESCRIPTION
## Purpose

Upgrade rust to 1.62. This is necessary since we need to upgrade tonic in the node to version 0.8 (for the upcoming grpc changes) which needs rust at least 1.56.

## Changes

Address new clippy suggestions. They do not change semantics or performance of the code.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.